### PR TITLE
Add -mempoolnotify flag to notify when a new transaction is added to the mempool.

### DIFF
--- a/contrib/debian/manpages/phore-qt.1
+++ b/contrib/debian/manpages/phore-qt.1
@@ -133,6 +133,9 @@ Set the number of threads to service RPC calls (default: 4)
 \fB\-blocknotify=\fR<cmd>
 Execute command when the best block changes (%s in cmd is replaced by block hash)
 .TP
+\fB\-mempoolnotify=\fR<cmd>
+Execute command when a new transaction is accepted to the mempool (%s in cmd is replaced by transaction hash)
+.TP
 \fB\-walletnotify=\fR<cmd>
 Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)
 .TP

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1634,7 +1634,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     // scan for better chains in the block chain database, that are not yet connected in the active best chain
     CValidationState state;
     if (!ActivateBestChain(state))
-        strErrors << "Failed t  o connect best block";
+        strErrors << "Failed to connect best block";
 
     std::vector<boost::filesystem::path> vImportFiles;
     if (mapArgs.count("-loadblock")) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6041,6 +6041,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                      pfrom->id, pfrom->cleanSubVer,
                      tx.GetHash().ToString(),
                      mempool.mapTx.size());
+            
+            uiInterface.NotifyTransaction(tx.GetHash());
 
             // Recursively process any orphan transactions that depended on this one
             set<NodeId> setMisbehaving;

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -101,6 +101,9 @@ public:
 
     /** New block has been accepted */
     boost::signals2::signal<void(const uint256& hash)> NotifyBlockTip;
+
+    /** New transaction has been added to the mempool */
+    boost::signals2::signal<void(const uint256& hash)> NotifyTransaction;
 };
 
 extern CClientUIInterface uiInterface;


### PR DESCRIPTION
This should allow more flexibility for external application interacting with the Phore daemon. Specifically, this is needed for a new feature in phoreproject/phore-rpc-proxy which allows clients to subscribe to notifications through WebSockets about various addresses, transactions, outputs, and blocks.